### PR TITLE
Override new `arrowParens` default in Prettier 2.0

### DIFF
--- a/index.json
+++ b/index.json
@@ -7,5 +7,6 @@
   "singleQuote": true,
   "tabWidth": 4,
   "trailingComma": "es5",
-  "useTabs": false
+  "useTabs": false,
+  "arrowParens": "avoid"
 }


### PR DESCRIPTION
Back to the 1.0 default